### PR TITLE
fix: address Next.js 15+ breaking changes and Prisma SQLite compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ node_modules
 *.log
 prisma/dev.db
 prisma/dev.db-journal
+
+# system prompt
+AGENTS.md
+
+# system files
+.DS_Store
+nvm-exec
+nvm.sh

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,11 +8,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { authOptions } from '@/lib/auth';
 
 interface HomeProps {
-  searchParams?: { page?: string };
+  searchParams?: Promise<{ page?: string }>;
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const page = Math.max(Number(searchParams?.page ?? '1'), 1);
+  const resolvedSearchParams = await searchParams;
+  const page = Math.max(Number(resolvedSearchParams?.page ?? '1'), 1);
   const [total, reports, session] = await Promise.all([
     prisma.report.count(),
     prisma.report.findMany({

--- a/app/reports/[id]/edit/page.tsx
+++ b/app/reports/[id]/edit/page.tsx
@@ -10,17 +10,18 @@ import { Button } from '@/components/ui/button';
 import { parseSeries } from '@/lib/validators/report';
 
 interface EditReportPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export default async function EditReportPage({ params }: EditReportPageProps) {
+  const resolvedParams = await params;
   const session = await getServerSession(authOptions);
   if (!session) {
     redirect('/signin');
   }
 
   const report = await prisma.report.findUnique({
-    where: { id: params.id }
+    where: { id: resolvedParams.id }
   });
 
   if (!report) {

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -10,12 +10,13 @@ import { deleteReport } from '@/app/reports/actions';
 import { parseSeries } from '@/lib/validators/report';
 
 interface ReportDetailPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export default async function ReportDetailPage({ params }: ReportDetailPageProps) {
+  const resolvedParams = await params;
   const report = await prisma.report.findUnique({
-    where: { id: params.id }
+    where: { id: resolvedParams.id }
   });
 
   if (!report) {

--- a/app/reports/actions.ts
+++ b/app/reports/actions.ts
@@ -119,5 +119,3 @@ export async function deleteReport(_: FormState, formData: FormData): Promise<Fo
   revalidatePath('/');
   redirect('/');
 }
-
-export const initialFormState = emptyState;

--- a/components/report/ReportForm.tsx
+++ b/components/report/ReportForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useFormState, useFormStatus } from 'react-dom';
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -29,7 +30,7 @@ function SubmitButton({ label }: { label: string }) {
 }
 
 export function ReportForm({ action, defaultValues, submitLabel, reportId }: ReportFormProps) {
-  const [state, formAction] = useFormState(action, initialState);
+  const [state, formAction] = useActionState(action, initialState);
 
   return (
     <form action={formAction} className="space-y-6">

--- a/docs/issues/issue1-fix-nextjs-15-breaking-changes.md
+++ b/docs/issues/issue1-fix-nextjs-15-breaking-changes.md
@@ -1,0 +1,31 @@
+### Summary
+Next.js 15 へのアップグレードに伴う破壊的変更（searchParams の非同期化および use server ファイルのエクスポート制限）によりアプリケーションが実行不能になるエラーを修正します。
+
+### Prerequisites
+- **Framework:** Next.js 15.x
+- **Affected Files:** - `app/page.tsx`
+  - `app/reports/actions.ts`
+- **Reproducible:** Always (Runtime Error)
+
+### Step to Reproduce
+1. `npm run dev` で開発サーバーを起動
+2. ブラウザでトップページ（/）にアクセス
+3. 実行時のコンソールおよびブラウザ上のエラーを確認
+
+### Actual Behavior
+以下の２つのエラーが発生し、ページが正常にレンダリングされません。
+#### Error1: `searchParams` unwrap error
+Error: Route "/" used ``searchParams.page``. `searchParams` is a Promise and must be unwrapped with `await` or `React.use()` before accessing its properties.`
+#### Error2: Invalid Server Action export
+`Error: A "use server" file can only export async functions, found object.`
+
+### Expected Behavior
+1. `app/page.tsx`において、`searchParams`が非同期（Promise）として適切に処理（`await`または`use()`）され、プロパティにアクセスできること。
+2. `app/reports/actions.ts`(`use server`)からは非同期関数のみがエクスポートされ、定数等のエクスポートによるビルドエラーが発生しないこと。
+
+### Proposed Solution / Fix Plan
+- `app/page.tsx`:
+  - Pageコンポーネントの引数`searchParams`を`await`で解決するように修正
+  - `const { page } = await searchParams;`の形式を採用
+- `app/reports/actions.ts`:
+  - `export const initialFormState`の定義を別ファイル（例：`types.ts`または`constants.ts`）に移動、もしくは使用前のコンポーネント内にカプセル化する。

--- a/docs/working-log/2026-03-29.md
+++ b/docs/working-log/2026-03-29.md
@@ -1,0 +1,55 @@
+# 日報 2026-03-29
+
+## ブランチ
+- fix/nextjs-15-breaking-changes
+
+## 参照Issue
+- /Users/kenshi/develop/codex/ReportingService/docs/issues/issue1-fix-nextjs-15-breaking-changes.md
+
+## 作業概要
+- Next.js 15/16 の破壊的変更対応（`searchParams`/`params`の非同期化、Server Actionのエクスポート制限）を適用。
+- Prisma/SQLite 互換に向けたデータ型変更と保存形式の見直し（JSON文字列化）を実施。
+- フロントフォームの React 19 変更に追随（`useFormState`→`useActionState`）。
+- Vercel/セットアップ/ドキュメントの更新とテスト実行。
+
+## 実施内容
+- Next.js 15 変更対応:
+  - `app/page.tsx` の `searchParams` を `await` で解決。
+  - `app/reports/[id]/page.tsx` / `app/reports/[id]/edit/page.tsx` の `params` を `await` で解決。
+  - `app/reports/actions.ts` の非同期関数以外のエクスポートを削除。
+- React 19 対応:
+  - `components/report/ReportForm.tsx` で `useActionState` に移行。
+- Prisma/SQLite 対応:
+  - `prisma/schema.prisma` の `Json`/`enum` を `String` に変更。
+  - `lib/validators/report.ts` に JSON 文字列の生成/解析を追加。
+  - `app/reports/actions.ts` / `app/api/*` で保存形式を JSON 文字列化に変更。
+  - `prisma/seed.ts` を JSON 文字列保存に修正。
+- セットアップ/ドキュメント:
+  - `setup.sh` に Prisma migrate 失敗時の SQLite 直接作成フォールバックを追加。
+  - `README.md` に Next 16 前提の Vercel 設定と環境変数例を追記。
+  - `docs/data-model.md` / `docs/detail-design.md` / `docs/assumptions.md` を保存形式の変更に合わせて更新。
+
+## 動作確認
+- `npm test` 実行: 3/3 成功
+- `npx prisma generate` 実行: 成功
+- `npm run seed` 実行: 成功（サンプル2件投入）
+
+## 影響ファイル
+- app/page.tsx
+- app/reports/actions.ts
+- app/reports/[id]/page.tsx
+- app/reports/[id]/edit/page.tsx
+- components/report/ReportForm.tsx
+- components/report/ReportChart.tsx
+- lib/validators/report.ts
+- prisma/schema.prisma
+- prisma/seed.ts
+- setup.sh
+- README.md
+- docs/data-model.md
+- docs/detail-design.md
+- docs/assumptions.md
+
+## 残タスク/注意点
+- `npm run dev` でのUI動作確認を継続し、追加エラーがあれば修正。
+- Node 25 環境の場合、Prisma migrate が不安定なため `setup.sh` のフォールバックを使用する。


### PR DESCRIPTION
## Summary
- Fixed Next.js 15+ breaking changes (async `searchParams`/`params`, server action export constraints)
- Updated React 19 form handling (`useFormState` → `useActionState`)
- Made Prisma schema SQLite-compatible (stringified JSON instead of Json/enum)
- Added SQLite fallback in setup for environments where Prisma migrate fails
- Updated docs and Vercel deployment notes for Next 16

## Changes
- Async params fixes in:
  - app/page.tsx
  - app/reports/[id]/page.tsx
  - app/reports/[id]/edit/page.tsx
- Server Action export cleanup in:
  - app/reports/actions.ts
- Prisma schema/data handling:
  - prisma/schema.prisma
  - prisma/seed.ts
  - lib/validators/report.ts
  - app/api/reports/*
- React 19 update:
  - components/report/ReportForm.tsx
- Setup & docs:
  - setup.sh
  - README.md
  - docs/data-model.md / docs/detail-design.md / docs/assumptions.md

## Verification
- npm test (3/3 passed)
- npx prisma generate (success)
- npm run seed (success)

## Notes
- Prisma migrate was unstable in Node 25; added fallback to create SQLite table directly.
- Data is stored as JSON string in `data` column.


## 概要
- Next.js 15+ の破壊的変更（async化された searchParams/params、Server Action の export制限）に対応
- React 19 の form API 変更に追随（useFormState → useActionState）
- Prisma の SQLite 互換対応（Json/enum を文字列保存に変更）
- Prisma migrate が不安定な環境向けに SQLite 直接作成フォールバックを追加
- Vercel設定およびドキュメントを Next 16 前提に更新

## 変更内容
- async params 修正:
  - app/page.tsx
  - app/reports/[id]/page.tsx
  - app/reports/[id]/edit/page.tsx
- Server Action export整理:
  - app/reports/actions.ts
- Prisma/SQLite 対応:
  - prisma/schema.prisma
  - prisma/seed.ts
  - lib/validators/report.ts
  - app/api/reports/*
- React 19 対応:
  - components/report/ReportForm.tsx
- セットアップ/ドキュメント:
  - setup.sh
  - README.md
  - docs/data-model.md / docs/detail-design.md / docs/assumptions.md

## 動作確認
- npm test（3/3 成功）
- npx prisma generate（成功）
- npm run seed（成功）

## 補足
- Node 25 環境で Prisma migrate が不安定だったため、setup.sh に SQLite 直接作成のフォールバックを追加
- data カラムは JSON 文字列で保持

## 関連Issue
Closes #1 